### PR TITLE
add Fluffocus mastery toggle button

### DIFF
--- a/src/components/Fluffy/InputSection.tsx
+++ b/src/components/Fluffy/InputSection.tsx
@@ -84,6 +84,16 @@ function InputSection({ index, instance, universe, renderParent }: Props) {
       }
     }
 
+    if (type === "Fluffocus") {
+      instance.purchasedFluffyBonus = !instance.purchasedFluffyBonus;
+
+      if (instance.instantUpdating) {
+        instance.expBonus = instance.getExpBonus();
+        instance.updateDisplayData();
+        renderParent();
+      }
+    }
+
     if (type === "Calculate") {
       instance.updateDisplayData();
       renderParent();
@@ -200,6 +210,19 @@ function InputSection({ index, instance, universe, renderParent }: Props) {
                   active={instance.graphNextIce}
                   onClick={() => {
                     handleClick("Ice");
+                  }}
+                />
+              </Label>
+            )}
+
+            {universe === 1 && (
+              <Label>
+                Fluffocus Mastery
+                <MemoTrueFalseButton
+                  colors={false}
+                  active={instance.purchasedFluffyExpBonus}
+                  onClick={() => {
+                    handleClick("Fluffocus");
                   }}
                 />
               </Label>


### PR DESCRIPTION
In the same way as the button for toggling ice enlightenment manually, sometimes you know you _will_ have Fluffocus for your next portal. Or sometimes you just want to try out how much it would help or hurt to have it or not.

This addition is entirely untested, but I have looked it over three times. It is as far as i can tell 100% correct.