### PR TITLE
Allow filtering out (blacklisting) of daily challenge mods

### DIFF
--- a/src/components/Daily/Context.tsx
+++ b/src/components/Daily/Context.tsx
@@ -23,15 +23,19 @@ const DailyProvider = ({ children }) => {
   };
 
   const updateDailiesFiltered = () => {
-    const goodMods = Object.keys(filterTypes).filter((x) => filterTypes[x]);
+    const goodMods = Object.keys(filterTypes).filter((x) => filterTypes[x] > 0);
+    const badMods = Object.keys(filterTypes).filter((x) => filterTypes[x] < 0);
     for (var x = 0; x < dailies.length; x++) {
       if (Object.keys(dailies[x]).length === 0) continue;
 
-      let matched = 0;
+      let matched = badMods.length;
 
       Object.keys(dailies[x].mods).forEach((y, i) => {
         if (goodMods.indexOf(y) !== -1) {
           matched += 1;
+        }
+        if (badMods.indexOf(y) !== -1) {
+          matched -= 1;
         }
       });
 

--- a/src/components/Daily/Filter.tsx
+++ b/src/components/Daily/Filter.tsx
@@ -102,7 +102,7 @@ function Filter() {
               className="mr-2"
               onClick={() => {
                 for (var type in filterTypes) {
-                  filterTypes[type] = !filterTypes[type];
+                  filterTypes[type] = filterTypes[type] ? 0 : 1;
                 }
 
                 setFlipAll(!flipAll);

--- a/src/components/Daily/Filter.tsx
+++ b/src/components/Daily/Filter.tsx
@@ -6,36 +6,36 @@ import Label from "../utils/Label";
 import { DailyContext } from "./Context";
 
 export var filterTypes = {
-  minDamage: true,
-  maxDamage: true,
-  plague: true,
-  weakness: true,
-  large: true,
-  dedication: true,
-  famine: true,
-  badStrength: true,
-  badHealth: true,
-  badMapStrength: true,
-  badMapHealth: true,
-  crits: true,
-  bogged: true,
-  dysfunctional: true,
-  oddTrimpNerf: true,
-  evenTrimpBuff: true,
-  karma: true,
-  toxic: true,
-  bloodthirst: true,
-  explosive: true,
-  slippery: true,
-  rampage: true,
-  mutimps: true,
-  empower: true,
-  pressure: true,
-  mirrored: true,
-  metallicThumb: true,
-  trimpCritChanceUp: true,
-  trimpCritChanceDown: true,
-  hemmorrhage: true,
+  minDamage: 0,
+  maxDamage: 0,
+  plague: 0,
+  weakness: 0,
+  large: 0,
+  dedication: 0,
+  famine: 0,
+  badStrength: 0,
+  badHealth: 0,
+  badMapStrength: 0,
+  badMapHealth: 0,
+  crits: 0,
+  bogged: 0,
+  dysfunctional: 0,
+  oddTrimpNerf: 0,
+  evenTrimpBuff: 0,
+  karma: 0,
+  toxic: 0,
+  bloodthirst: 0,
+  explosive: 0,
+  slippery: 0,
+  rampage: 0,
+  mutimps: 0,
+  empower: 0,
+  pressure: 0,
+  mirrored: 0,
+  metallicThumb: 0,
+  trimpCritChanceUp: 0,
+  trimpCritChanceDown: 0,
+  hemmorrhage: 0,
 };
 
 declare const window: any;
@@ -50,11 +50,11 @@ function FilterBox({ type }: { type: string }) {
     <>
       <div
         className={clsx(
-          filterTypes[type] ? "bg-tier3" : "bg-tier1",
+          filterTypes[type] < 0 ? "bg-tier3" : filterTypes[type] ? "bg-tier1" : "bg-grey",
           "m-0.5 p-1 w-min text-black text-xxs shadow cursor-pointer select-none sm:text-xs md:text-sm"
         )}
         onClick={() => {
-          filterTypes[type] = !filterTypes[type];
+          filterTypes[type] = ((filterTypes[type] + 2) % 3) - 1;
 
           updateDailiesFiltered();
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
     extend: {
       colors: {
         prpl: "#A775FA",
+        grey: "#999999",
         tier1: "#DD7E6B",
         tier2: "#AFCB77",
         tier3: "#62BD87",


### PR DESCRIPTION
This adds a third state to the filters of the Daily Seeker tool.  Each mod can now be set to neutral (new grey color, same behavior as the default red color from before); whitelisted (same color and behavior as green from before); or blacklisted (red color, new behavior).  Blacklisted mods count as a match if a given daily challenge does **not** include that mod.

This change is **untested**, as I'm not very familiar with Node and React, and wasn't able to get the project running (even before making changes).  If anything doesn't work, and you'd like me to sort it out, a brief instruction on how to build and run the project  from a clean checkout would be much appreciated.

I wasn't exactly sure what to do with the "Flip All" button in this new trinary filter scheme.  For simplicity's sake, I made it flip both blacklisted and whitelisted to neutral, and flip neutral to whitelisted.  Alternatives include cycling each the way an individual click does (neutral->whitelisted->blacklisted->neutral) and making separate buttons to set everything to a single state.  I'm not sure what `setFlipAll(!flipAll)` does, so I didn't try either of those.

Another possible improvement is to have separate match requirements for whitelisted and blacklisted mods -- e.g., show dailies which match at least 2 of the mods I whitelisted, but match (don't have) all 3 of the mods I blacklisted.