### PR TITLE
Add Frigid challenge completions to UI and XP calculations

### DIFF
--- a/src/calculators/fluffy.ts
+++ b/src/calculators/fluffy.ts
@@ -67,7 +67,7 @@ export class fluffyInstance {
   instantUpdating = false;
   minutesPerRun = 14;
   averageWorshippers = 0;
-
+  frigidCompletions = 0;
   //
   currentExp = 0;
 
@@ -147,6 +147,9 @@ export class fluffyInstance {
     }
     if (this.graphNextIce && this.iceBonus > 1) {
       num *= this.iceBonus;
+    }
+    if (this.frigidCompletions > 0) {
+      num *= 1 + (((this.frigidCompletions / 2) * (this.frigidCompletions + 1)) / 40);
     }
 
     if (this.universe === 2) {
@@ -468,6 +471,8 @@ export class fluffyInstance {
 
     this.iceBonus =
       this.universe === 1 ? 1 + 0.0025 * gameSave.empowerments.Ice.level : 1;
+    
+    this.frigidCompletions = gameSave.global.frigidCompletions;
 
     this.expBonus = this.getExpBonus();
 
@@ -528,6 +533,10 @@ export class fluffyInstance {
         break;
       case "Knowledge Level":
         this.traps.level = Number(value);
+        this.expBonus = this.getExpBonus();
+        break;
+      case "Frigid Completions":
+        this.frigidCompletions = Number(value);
         this.expBonus = this.getExpBonus();
         break;
       case "Average Worshippers":

--- a/src/components/Fluffy/InputSection.tsx
+++ b/src/components/Fluffy/InputSection.tsx
@@ -227,6 +227,17 @@ function InputSection({ index, instance, universe, renderParent }: Props) {
                 />
               </Label>
             )}
+            
+            {universe === 1 && (
+              <Label>
+                Frigid Completions
+                <Input
+                  variant="fluffy"
+                  max={15}
+                  defaultValue={instance?.frigidCompletions || 0}
+                  />
+              </Label>
+            )}
 
             {universe === 2 && (
               <Label>


### PR DESCRIPTION
With Frigid boosting Fluffy experience gains so much, I figured it would be useful to include completions in the calcs so players can plan ahead appropriately. The other day I had a pleasant surprise of a levelled Fluffy much earlier than projected, which spurred me into looking into this. :) 

I brought the formula over from the Trimps source, but couldn't figure out how to check if the challenge was unlocked and hide it correspondingly. Otherwise, I've tested everything on my machine and think it's good to go!